### PR TITLE
Fix clear-text logging of sensitive information

### DIFF
--- a/exercise/javascript/errorhandler.js
+++ b/exercise/javascript/errorhandler.js
@@ -21,4 +21,4 @@ const configurations = {
     }
 };
 
-console.log(configurations);
+// Removed the console.log(configurations) statement to avoid logging sensitive information


### PR DESCRIPTION
Related to #10

Remove the clear-text logging of sensitive information in `exercise/javascript/errorhandler.js`.

* Remove the `console.log(configurations);` statement to prevent logging sensitive information.
* Add a comment explaining the removal of the logging statement to avoid logging sensitive information.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/GitHub-Avanade-Au-Lab/ava-ghcopilot-workshop-ato/issues/10?shareId=dad46a58-702d-42c8-813f-98197d017831).